### PR TITLE
Implementación de nuevas rutas y mejora a los logs

### DIFF
--- a/docs/config/fbcache.config.json
+++ b/docs/config/fbcache.config.json
@@ -11,9 +11,10 @@
         {
             "name": "persons",
             "period": "2 m",
-            "start": "2020-09-17 12:38:30 am",
+            "start": "2020-09-24 12:38:30 am",
             "read_only": false
         }
     ],
-    "max_size": "50 MB"
+    "max_size": "50 MB",
+    "logs": "debug"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2953,8 +2953,8 @@
       }
     },
     "fbcache": {
-      "version": "git+https://github.com/synergyvision/fbcache.git#0c48027e365c12373e916d07aecfac80c40053ec",
-      "from": "git+https://github.com/synergyvision/fbcache.git#refactor",
+      "version": "git+https://github.com/synergyvision/fbcache.git#5bc6acdedd83a87427dc81a878a0773ab3dd95a5",
+      "from": "git+https://github.com/synergyvision/fbcache.git#dev",
       "requires": {
         "firebase-admin": "^9.1.1",
         "moment": "^2.27.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1407,9 +1407,9 @@
       }
     },
     "@firebase/database": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.12.tgz",
-      "integrity": "sha512-OLUxp8TkXiML4X5LWM5IACsSDvo3fcf4mTbTe5RF+N6TRFv0Svzlet5OgGIa3ET1dQvNiisrMX7zzRa0OTLs7Q==",
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.13.tgz",
+      "integrity": "sha512-NommVkAPzU7CKd1gyehmi3lz0K78q0KOfiex7Nfy7MBMwknLm7oNqKovXSgQV1PCLvKXvvAplDSFhDhzIf9obA==",
       "requires": {
         "@firebase/auth-interop-types": "0.1.5",
         "@firebase/component": "0.1.19",
@@ -1551,9 +1551,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.1.6.tgz",
-      "integrity": "sha512-bUeaMN/dHTkt9AqU0Tc1xdHMB3jVLyPNfg8gZ5cMyhFyMeCwoJbFcJrNBgYqRCbvYhvtaEgzQwkw91NnY4Oktg==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.1.7.tgz",
+      "integrity": "sha512-EuxMstI0u778dp0nk6Fe3gHXYPeV6FYsWOe0/QFwxv1NQ6bc5Wl/0Yxa4xl9uBlKElL6AIxuASmSfu7KEJhqiw==",
       "optional": true,
       "requires": {
         "@grpc/proto-loader": "^0.6.0-pre14",
@@ -1576,9 +1576,9 @@
           }
         },
         "@types/node": {
-          "version": "12.12.61",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.61.tgz",
-          "integrity": "sha512-+/KPk6uV9qGfVX0y2uUj3y8O0Z6KZWUy3XTS0uQGYYF+iXGtepm9GPETdcRq+hGmErkLOr5QJDX8vuymkwu4sA==",
+          "version": "12.12.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+          "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg==",
           "optional": true
         }
       }
@@ -1728,12 +1728,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "optional": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -2957,7 +2957,7 @@
       }
     },
     "fbcache": {
-      "version": "git+https://github.com/synergyvision/fbcache.git#3c2c494396b7634a4a53c17f7f1aeab5bbe14e7a",
+      "version": "git+https://github.com/synergyvision/fbcache.git#3d8db922d6eee118138a036f143cad0dfd86a5cd",
       "from": "git+https://github.com/synergyvision/fbcache.git#dev",
       "requires": {
         "firebase-admin": "^9.1.1",
@@ -3221,9 +3221,9 @@
       "dev": true
     },
     "google-auth-library": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.6.tgz",
-      "integrity": "sha512-fWYdRdg55HSJoRq9k568jJA1lrhg9i2xgfhVIMJbskUmbDpJGHsbv9l41DGhCDXM21F9Kn4kUwdysgxSYBYJUw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.0.tgz",
+      "integrity": "sha512-GbalszIADE1YPWhUyfFMrkLhFHnlAgoRcqGVW+MsLDPsuaOB5MRPk7NNafPDv9SherNE4EKzcYuxMJjaxzXMOw==",
       "optional": true,
       "requires": {
         "arrify": "^2.0.0",
@@ -3446,12 +3446,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "optional": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -3473,12 +3473,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "optional": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -4274,9 +4274,9 @@
       }
     },
     "moment": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.28.0.tgz",
-      "integrity": "sha512-Z5KOjYmnHyd/ukynmFd/WwyXHd7L4J9vTI/nn5Ap9AVUgaAE15VvQ9MOGmJJygEUklupqIrFnor/tjTwRU+tQw=="
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.0.tgz",
+      "integrity": "sha512-z6IJ5HXYiuxvFTI6eiQ9dm77uE0gyy1yXNApVHqTcnIKfY9tIwEjlzsZ6u1LQXvVgKeTnv9Xm7NDvJ7lso3MtA=="
     },
     "morgan": {
       "version": "1.10.0",
@@ -5045,12 +5045,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "optional": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1456,20 +1456,6 @@
         "google-auth-library": "^6.0.0",
         "retry-request": "^4.1.1",
         "teeny-request": "^7.0.0"
-      },
-      "dependencies": {
-        "duplexify": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
-          "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
-          "optional": true,
-          "requires": {
-            "end-of-stream": "^1.4.1",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1",
-            "stream-shift": "^1.0.0"
-          }
-        }
       }
     },
     "@google-cloud/firestore": {
@@ -1533,6 +1519,18 @@
         "xdg-basedir": "^4.0.0"
       },
       "dependencies": {
+        "duplexify": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+          "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+          "optional": true,
+          "requires": {
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
         "mime": {
           "version": "2.4.6",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
@@ -1546,6 +1544,30 @@
           "optional": true,
           "requires": {
             "p-try": "^2.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -2601,41 +2623,15 @@
       "dev": true
     },
     "duplexify": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+      "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
       "optional": true,
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
         "stream-shift": "^1.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "ecdsa-sig-formatter": {
@@ -2957,8 +2953,8 @@
       }
     },
     "fbcache": {
-      "version": "git+https://github.com/synergyvision/fbcache.git#3d8db922d6eee118138a036f143cad0dfd86a5cd",
-      "from": "git+https://github.com/synergyvision/fbcache.git#dev",
+      "version": "git+https://github.com/synergyvision/fbcache.git#0c48027e365c12373e916d07aecfac80c40053ec",
+      "from": "git+https://github.com/synergyvision/fbcache.git#refactor",
       "requires": {
         "firebase-admin": "^9.1.1",
         "moment": "^2.27.0",
@@ -3238,25 +3234,21 @@
       }
     },
     "google-gax": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.8.0.tgz",
-      "integrity": "sha512-MPaADY/FHittX5xfOUU2EVqIoE850e+OZ1ys8aO2GnUMaP4U0Bde2wop6kw5sp4fIOjKNlan4GATKAURsYbxSw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.9.0.tgz",
+      "integrity": "sha512-MFMwA7Fb8PEwjnYwfGXjZMidCNyMl3gSnvS/+kS8TQioJZQDpzK+W3dmwyNyig/U13+kbABqDnbkkAXJ5NiUkw==",
       "optional": true,
       "requires": {
         "@grpc/grpc-js": "~1.1.1",
         "@grpc/proto-loader": "^0.5.1",
         "@types/long": "^4.0.0",
         "abort-controller": "^3.0.0",
-        "duplexify": "^3.6.0",
+        "duplexify": "^4.0.0",
         "google-auth-library": "^6.0.0",
         "is-stream-ended": "^0.1.4",
-        "lodash.at": "^4.6.0",
-        "lodash.has": "^4.5.2",
-        "node-fetch": "^2.6.0",
+        "node-fetch": "^2.6.1",
         "protobufjs": "^6.9.0",
-        "retry-request": "^4.0.0",
-        "semver": "^6.0.0",
-        "walkdir": "^0.4.0"
+        "retry-request": "^4.0.0"
       }
     },
     "google-p12-pem": {
@@ -3950,22 +3942,10 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
-    "lodash.at": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.at/-/lodash.at-4.6.0.tgz",
-      "integrity": "sha1-k83OZk8KGZTqM9181A4jr9EbD/g=",
-      "optional": true
-    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "optional": true
-    },
-    "lodash.has": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=",
       "optional": true
     },
     "lodash.includes": {
@@ -4798,20 +4778,6 @@
         "duplexify": "^4.1.1",
         "inherits": "^2.0.3",
         "pump": "^3.0.0"
-      },
-      "dependencies": {
-        "duplexify": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
-          "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
-          "optional": true,
-          "requires": {
-            "end-of-stream": "^1.4.1",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1",
-            "stream-shift": "^1.0.0"
-          }
-        }
       }
     },
     "pupa": {
@@ -5839,12 +5805,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "walkdir": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
-      "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==",
-      "optional": true
     },
     "websocket-driver": {
       "version": "0.7.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "axios": "^0.20.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "fbcache": "git+https://github.com/synergyvision/fbcache.git#dev",
+    "fbcache": "git+https://github.com/synergyvision/fbcache.git#refactor",
     "morgan": "^1.10.0",
     "winston": "^3.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "axios": "^0.20.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "fbcache": "git+https://github.com/synergyvision/fbcache.git#refactor",
+    "fbcache": "git+https://github.com/synergyvision/fbcache.git#dev",
     "morgan": "^1.10.0",
     "winston": "^3.3.3"
   },

--- a/src/app/server.js
+++ b/src/app/server.js
@@ -3,6 +3,7 @@ import morgan from 'morgan';
 import axios from "axios";
 import { config } from "../enviroment";
 import { logger } from "../utils/logger";
+import { loggerController } from "../services/logger/logger.controller";
 import { FBCache } from "fbcache";
 import { apiRouter } from "../routes/api.routes";
 
@@ -10,14 +11,18 @@ const initFBCache = async (credential) => {
     let fbcConfig = null;
     if (config.CONFIG === "local"){
         fbcConfig = require(config.CONFIG_LOCATION);
+        if(fbcConfig.logs)
+            loggerController.setLevel(fbcConfig.logs)
         FBCache.init(fbcConfig, config.URL, config.CREDENTIAL_TYPE, credential);
-        logger.info("FBCache is initialized - config in local");
+        loggerController.info("FBCache is initialized - config in local");
     }
     else if (config.CONFIG === "web") {
         const response = await axios.get(config.CONFIG_LOCATION);
         fbcConfig = response.data;
+        if(fbcConfig.logs)
+            loggerController.setLevel(fbcConfig.logs)
         FBCache.init(fbcConfig, config.URL, config.CREDENTIAL_TYPE, credential);
-        logger.info("FBCache is initialized - config in web");
+        loggerController.info("FBCache is initialized - config in web");
     }
 };
 
@@ -52,7 +57,7 @@ app.use('/api', apiRouter);
 
 // ERROR HANDLER
 app.use(function(err, req, res, next) {
-    logger.error(err.message);
+    loggerController.error(err.message);
     res.status(500).send('Something broke!');
 });
 

--- a/src/app/server.js
+++ b/src/app/server.js
@@ -4,16 +4,16 @@ import axios from "axios";
 import { config } from "../enviroment";
 import { logger } from "../utils/logger";
 import { loggerController } from "../services/logger/logger.controller";
-import { FBCache } from "fbcache";
+import { initFBCache } from "fbcache";
 import { apiRouter } from "../routes/api.routes";
 
-const initFBCache = async (credential) => {
+const initFBC = async (credential) => {
     let fbcConfig = null;
     if (config.CONFIG === "local"){
         fbcConfig = require(config.CONFIG_LOCATION);
         if(fbcConfig.logs)
             loggerController.setLevel(fbcConfig.logs)
-        FBCache.init(fbcConfig, config.URL, config.CREDENTIAL_TYPE, credential);
+        initFBCache(fbcConfig, config.URL, config.CREDENTIAL_TYPE, credential);
         loggerController.info("FBCache is initialized - config in local");
     }
     else if (config.CONFIG === "web") {
@@ -21,7 +21,7 @@ const initFBCache = async (credential) => {
         fbcConfig = response.data;
         if(fbcConfig.logs)
             loggerController.setLevel(fbcConfig.logs)
-        FBCache.init(fbcConfig, config.URL, config.CREDENTIAL_TYPE, credential);
+        initFBCache(fbcConfig, config.URL, config.CREDENTIAL_TYPE, credential);
         loggerController.info("FBCache is initialized - config in web");
     }
 };
@@ -39,7 +39,7 @@ const firebaseCredential = {
     client_x509_cert_url: config.CREDENTIAL_FILE_CLIENT_CERT
 };
 
-initFBCache(firebaseCredential);
+initFBC(firebaseCredential);
 export const app = express();
 
 // MIDDLEWARES

--- a/src/services/logger/logger.controller.js
+++ b/src/services/logger/logger.controller.js
@@ -1,0 +1,45 @@
+import { logger } from "../../utils/logger";
+
+const controller = {};
+
+let logLevel = "info";
+
+controller.setLevel = (level) => {
+    switch (level) {
+        case "info":
+        logLevel = "info";
+        break;
+    
+        case "debug":
+        logLevel = "debug";
+        break;
+
+        case "error":
+        logLevel = "error";
+        break;
+
+        default:
+            logger.warn("logLevel have an invalid value, logLevel in info level")
+        break;
+    }
+}
+
+controller.error = (mes) => {
+    logger.error(mes);
+}
+
+controller.warn = (mes) => {
+    logger.warn(mes);
+}
+
+controller.info = (mes) => {
+    if(logLevel !== "error")
+        logger.info(mes);
+}
+
+controller.debug = (mes) => {
+    if(logLevel === "debug")
+        logger.debug(mes);
+}
+
+export const loggerController = controller;

--- a/src/services/persons/persons.controller.js
+++ b/src/services/persons/persons.controller.js
@@ -1,6 +1,6 @@
 import { loggerController } from "../logger/logger.controller";
 import { FBCache, service } from "fbcache";
-import { logger } from "../../utils/logger";
+const util = require('util')
 
 const controller = {};
 
@@ -15,7 +15,7 @@ controller.getAll = async (req, res, next) => {
             loggerController.info(`[${context}] get persons from cache`);
         else
             loggerController.warn(`[${context}] get persons from Real Time Database`);
-        loggerController.debug(`FBCache response: ${resp}`);
+        loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
         next(error);
@@ -26,7 +26,7 @@ controller.insert = async (req, res, next) => {
     const info = req.body;
     let resp = null;
     loggerController.debug(`[${context}] insert`);
-    loggerController.debug(`body recibed: ${info}`);
+    loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
     loggerController.debug(`route especified: persons`);
     try {
         resp = await FBCache.insert(service.REAL_TIME, "persons", info);
@@ -34,7 +34,7 @@ controller.insert = async (req, res, next) => {
             loggerController.info(`[${context}] insert refreshed cache`);
         else
             loggerController.warn(`[${context}] insert don't refreshed cache`);
-        loggerController.debug(`FBCache response: ${resp}`);
+        loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
         next(error);
@@ -47,7 +47,7 @@ controller.insertWithID = async (req, res, next) => {
     let resp = null;
     loggerController.debug(`[${context}] insertWithID`);
     loggerController.debug(`param 'id' recibed: ${id}`);
-    loggerController.debug(`body recibed: ${info}`);
+    loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
     loggerController.debug(`route especified: persons`);
     try {
         resp = await FBCache.insert(service.REAL_TIME, "persons", info, id);
@@ -55,7 +55,7 @@ controller.insertWithID = async (req, res, next) => {
             loggerController.info(`[${context}] insert refreshed cache`);
         else
             loggerController.warn(`[${context}] insert don't refreshed cache`);
-        loggerController.debug(`FBCache response: ${resp}`);
+        loggerController.debug(`FBCache response: ${util.inspect(info, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
         next(error);
@@ -68,7 +68,7 @@ controller.update = async (req, res, next) => {
     let resp = null;
     loggerController.debug(`[${context}] update`);
     loggerController.debug(`param 'id' recibed: ${id}`);
-    loggerController.debug(`body recibed: ${info}`);
+    loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
     loggerController.debug(`route especified: persons`);
     try {
         resp = await FBCache.update(service.REAL_TIME, "persons", info, id);
@@ -76,7 +76,7 @@ controller.update = async (req, res, next) => {
             loggerController.info(`[${context}] update refreshed cache`);
         else
             loggerController.warn(`[${context}] update don't refreshed cache`);
-        loggerController.debug(`FBCache response: ${resp}`);
+        loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
         next(error);
@@ -95,7 +95,7 @@ controller.delete = async (req, res, next) => {
             loggerController.info(`[${context}] delete refreshed cache`);
         else
             loggerController.warn(`[${context}] delete don't refreshed cache`);
-        loggerController.debug(`FBCache response: ${resp}`);
+        loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
         next(error);

--- a/src/services/persons/persons.controller.js
+++ b/src/services/persons/persons.controller.js
@@ -1,18 +1,21 @@
-import { logger } from "../../utils/logger";
+import { loggerController } from "../logger/logger.controller";
 import { FBCache, service } from "fbcache";
+import { logger } from "../../utils/logger";
 
 const controller = {};
 
 const context = "Persons Controller"
 
 controller.getAll = async (req, res, next) => {
-    logger.info(`[${context}] getAll`);
+    loggerController.debug(`[${context}] getAll`);
+    loggerController.debug(`route especified: persons`);
     try {
         const resp = await FBCache.get(service.REAL_TIME, "persons");
         if(resp.cache)
-            logger.info(`[${context}] getAll persons from cache`);
+            loggerController.info(`[${context}] get persons from cache`);
         else
-            logger.warn(`[${context}] getAll persons from Real Time Database`);
+            loggerController.warn(`[${context}] get persons from Real Time Database`);
+        loggerController.debug(`FBCache response: ${resp}`);
         res.json(resp);
     } catch (error) {
         next(error);
@@ -22,16 +25,77 @@ controller.getAll = async (req, res, next) => {
 controller.insert = async (req, res, next) => {
     const info = req.body;
     let resp = null;
-    logger.info(`[${context}] insert`);
+    loggerController.debug(`[${context}] insert`);
+    loggerController.debug(`body recibed: ${info}`);
+    loggerController.debug(`route especified: persons`);
     try {
-        if(info.data)
-            resp = await FBCache.insert(service.REAL_TIME, "persons", info.data, info.id);
-        else
-            resp = await FBCache.insert(service.REAL_TIME, "persons", info.data);
+        resp = await FBCache.insert(service.REAL_TIME, "persons", info);
         if(resp.updateCache)
-            logger.info(`[${context}] insert update cache`);
+            loggerController.info(`[${context}] insert refreshed cache`);
         else
-            logger.warn(`[${context}] insert don't update cache`);
+            loggerController.warn(`[${context}] insert don't refreshed cache`);
+        loggerController.debug(`FBCache response: ${resp}`);
+        res.json(resp);
+    } catch (error) {
+        next(error);
+    }
+}
+
+controller.insertWithID = async (req, res, next) => {
+    const info = req.body;
+    const id = req.params.id;
+    let resp = null;
+    loggerController.debug(`[${context}] insertWithID`);
+    loggerController.debug(`param 'id' recibed: ${id}`);
+    loggerController.debug(`body recibed: ${info}`);
+    loggerController.debug(`route especified: persons`);
+    try {
+        resp = await FBCache.insert(service.REAL_TIME, "persons", info, id);
+        if(resp.updateCache)
+            loggerController.info(`[${context}] insert refreshed cache`);
+        else
+            loggerController.warn(`[${context}] insert don't refreshed cache`);
+        loggerController.debug(`FBCache response: ${resp}`);
+        res.json(resp);
+    } catch (error) {
+        next(error);
+    }
+}
+
+controller.update = async (req, res, next) => {
+    const info = req.body;
+    const id = req.params.id;
+    let resp = null;
+    loggerController.debug(`[${context}] update`);
+    loggerController.debug(`param 'id' recibed: ${id}`);
+    loggerController.debug(`body recibed: ${info}`);
+    loggerController.debug(`route especified: persons`);
+    try {
+        resp = await FBCache.update(service.REAL_TIME, "persons", info, id);
+        if(resp.updateCache)
+            loggerController.info(`[${context}] update refreshed cache`);
+        else
+            loggerController.warn(`[${context}] update don't refreshed cache`);
+        loggerController.debug(`FBCache response: ${resp}`);
+        res.json(resp);
+    } catch (error) {
+        next(error);
+    }
+}
+
+controller.delete = async (req, res, next) => {
+    const id = req.params.id;
+    let resp = null;
+    loggerController.debug(`[${context}] delete`);
+    loggerController.debug(`param 'id' recibed: ${id}`);
+    loggerController.debug(`route especified: persons`);
+    try {
+        resp = await FBCache.delete(service.REAL_TIME, "persons", id);
+        if(resp.updateCache)
+            loggerController.info(`[${context}] delete refreshed cache`);
+        else
+            loggerController.warn(`[${context}] delete don't refreshed cache`);
+        loggerController.debug(`FBCache response: ${resp}`);
         res.json(resp);
     } catch (error) {
         next(error);

--- a/src/services/persons/persons.controller.js
+++ b/src/services/persons/persons.controller.js
@@ -1,5 +1,5 @@
 import { loggerController } from "../logger/logger.controller";
-import { FBCache, service, FBCacheR } from "fbcache";
+import { FBCache } from "fbcache";
 const util = require('util')
 
 const controller = {};
@@ -9,7 +9,7 @@ const context = "Persons Controller"
 controller.getAll = async (req, res, next) => {
     loggerController.debug(`[${context}] getAll`);
     loggerController.debug(`route especified: persons`);
-    let fbc = new FBCacheR();
+    let fbc = new FBCache();
     try {
         const resp = await fbc.database().ref("persons").once();
         if(resp.cache)
@@ -26,7 +26,7 @@ controller.getAll = async (req, res, next) => {
 controller.insert = async (req, res, next) => {
     const info = req.body;
     let resp = null;
-    let fbc = new FBCacheR();
+    let fbc = new FBCache();
     loggerController.debug(`[${context}] insert`);
     loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
     loggerController.debug(`route especified: persons`);
@@ -47,7 +47,7 @@ controller.insertWithID = async (req, res, next) => {
     const info = req.body;
     const id = req.params.id;
     let resp = null;
-    let fbc = new FBCacheR();
+    let fbc = new FBCache();
     loggerController.debug(`[${context}] insertWithID`);
     loggerController.debug(`param 'id' recibed: ${id}`);
     loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
@@ -69,7 +69,7 @@ controller.update = async (req, res, next) => {
     const info = req.body;
     const id = req.params.id;
     let resp = null;
-    let fbc = new FBCacheR();
+    let fbc = new FBCache();
     loggerController.debug(`[${context}] update`);
     loggerController.debug(`param 'id' recibed: ${id}`);
     loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
@@ -90,7 +90,7 @@ controller.update = async (req, res, next) => {
 controller.delete = async (req, res, next) => {
     const id = req.params.id;
     let resp = null;
-    let fbc = new FBCacheR();
+    let fbc = new FBCache();
     loggerController.debug(`[${context}] delete`);
     loggerController.debug(`param 'id' recibed: ${id}`);
     loggerController.debug(`route especified: persons`);

--- a/src/services/persons/persons.controller.js
+++ b/src/services/persons/persons.controller.js
@@ -1,5 +1,5 @@
 import { loggerController } from "../logger/logger.controller";
-import { FBCache, service } from "fbcache";
+import { FBCache, service, FBCacheR } from "fbcache";
 const util = require('util')
 
 const controller = {};
@@ -9,8 +9,9 @@ const context = "Persons Controller"
 controller.getAll = async (req, res, next) => {
     loggerController.debug(`[${context}] getAll`);
     loggerController.debug(`route especified: persons`);
+    let fbc = new FBCacheR();
     try {
-        const resp = await FBCache.get(service.REAL_TIME, "persons");
+        const resp = await fbc.database().ref("persons").once();
         if(resp.cache)
             loggerController.info(`[${context}] get persons from cache`);
         else
@@ -25,6 +26,7 @@ controller.getAll = async (req, res, next) => {
 controller.insert = async (req, res, next) => {
     const info = req.body;
     let resp = null;
+    let fbc = new FBCacheR();
     loggerController.debug(`[${context}] insert`);
     loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
     loggerController.debug(`route especified: persons`);
@@ -45,12 +47,13 @@ controller.insertWithID = async (req, res, next) => {
     const info = req.body;
     const id = req.params.id;
     let resp = null;
+    let fbc = new FBCacheR();
     loggerController.debug(`[${context}] insertWithID`);
     loggerController.debug(`param 'id' recibed: ${id}`);
     loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
     loggerController.debug(`route especified: persons`);
     try {
-        resp = await FBCache.insert(service.REAL_TIME, "persons", info, id);
+        resp = await fbc.database().ref("persons").child(id).set(info);
         if(resp.updateCache)
             loggerController.info(`[${context}] insert refreshed cache`);
         else

--- a/src/services/persons/persons.controller.js
+++ b/src/services/persons/persons.controller.js
@@ -31,7 +31,7 @@ controller.insert = async (req, res, next) => {
     loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
     loggerController.debug(`route especified: persons`);
     try {
-        resp = await FBCache.insert(service.REAL_TIME, "persons", info);
+        resp = await fbc.database().ref().child("persons").push(info);
         if(resp.updateCache)
             loggerController.info(`[${context}] insert refreshed cache`);
         else
@@ -69,12 +69,13 @@ controller.update = async (req, res, next) => {
     const info = req.body;
     const id = req.params.id;
     let resp = null;
+    let fbc = new FBCacheR();
     loggerController.debug(`[${context}] update`);
     loggerController.debug(`param 'id' recibed: ${id}`);
     loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
     loggerController.debug(`route especified: persons`);
     try {
-        resp = await FBCache.update(service.REAL_TIME, "persons", info, id);
+        resp = await fbc.database().ref("persons").child(id).update(info);
         if(resp.updateCache)
             loggerController.info(`[${context}] update refreshed cache`);
         else
@@ -89,11 +90,12 @@ controller.update = async (req, res, next) => {
 controller.delete = async (req, res, next) => {
     const id = req.params.id;
     let resp = null;
+    let fbc = new FBCacheR();
     loggerController.debug(`[${context}] delete`);
     loggerController.debug(`param 'id' recibed: ${id}`);
     loggerController.debug(`route especified: persons`);
     try {
-        resp = await FBCache.delete(service.REAL_TIME, "persons", id);
+        resp = await fbc.database().ref("persons").child(id).remove();
         if(resp.updateCache)
             loggerController.info(`[${context}] delete refreshed cache`);
         else

--- a/src/services/persons/persons.routes.js
+++ b/src/services/persons/persons.routes.js
@@ -4,5 +4,8 @@ const router = Router();
 
 router.get('/', personsController.getAll)
 router.post('/', personsController.insert)
+router.post('/:id', personsController.insertWithID)
+router.put('/:id', personsController.update)
+router.delete('/:id', personsController.delete)
 
 export const personsRouter = router;

--- a/src/services/users/users.controller.js
+++ b/src/services/users/users.controller.js
@@ -1,5 +1,6 @@
 import { loggerController } from "../logger/logger.controller";
 import { FBCache, service } from "fbcache";
+const util = require('util')
 
 const controller = {};
 
@@ -14,6 +15,7 @@ controller.getAll = async (req, res, next) => {
             loggerController.info(`[${context}] get users from cache`);
         else
             loggerController.warn(`[${context}] get users from Firestore`);
+        loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
         next(error);
@@ -24,7 +26,7 @@ controller.insert = async (req, res, next) => {
     const info = req.body;
     let resp = null;
     loggerController.debug(`[${context}] insert`);
-    loggerController.debug(`body recibed: ${info}`);
+    loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
     loggerController.debug(`route especified: users`);
     try {
         resp = await FBCache.insert(service.FIRESTORE, "users", info);
@@ -32,7 +34,7 @@ controller.insert = async (req, res, next) => {
             loggerController.info(`[${context}] insert refreshed cache`);
         else
             loggerController.warn(`[${context}] insert don't refreshed cache`);
-        loggerController.debug(`FBCache response: ${resp}`);
+        loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
         next(error);
@@ -45,7 +47,7 @@ controller.insertWithID = async (req, res, next) => {
     let resp = null;
     loggerController.debug(`[${context}] insertWithID`);
     loggerController.debug(`param 'id' recibed: ${id}`);
-    loggerController.debug(`body recibed: ${info}`);
+    loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
     loggerController.debug(`route especified: users`);
     try {
         resp = await FBCache.insert(service.FIRESTORE, "users", info, id);
@@ -53,7 +55,7 @@ controller.insertWithID = async (req, res, next) => {
             loggerController.info(`[${context}] insert refreshed cache`);
         else
             loggerController.warn(`[${context}] insert don't refreshed cache`);
-        loggerController.debug(`FBCache response: ${resp}`);
+        loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
         next(error);
@@ -66,7 +68,7 @@ controller.update = async (req, res, next) => {
     let resp = null;
     loggerController.debug(`[${context}] update`);
     loggerController.debug(`param 'id' recibed: ${id}`);
-    loggerController.debug(`body recibed: ${info}`);
+    loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
     loggerController.debug(`route especified: users`);
     try {
         resp = await FBCache.update(service.FIRESTORE, "users", info, id);
@@ -74,7 +76,7 @@ controller.update = async (req, res, next) => {
             loggerController.info(`[${context}] update refreshed cache`);
         else
             loggerController.warn(`[${context}] update don't refreshed cache`);
-        loggerController.debug(`FBCache response: ${resp}`);
+        loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
         next(error);
@@ -86,14 +88,14 @@ controller.delete = async (req, res, next) => {
     let resp = null;
     loggerController.debug(`[${context}] delete`);
     loggerController.debug(`param 'id' recibed: ${id}`);
-    loggerController.debug(`route especified: persons`);
+    loggerController.debug(`route especified: users`);
     try {
         resp = await FBCache.delete(service.FIRESTORE, "users", id);
         if(resp.updateCache)
             loggerController.info(`[${context}] delete refreshed cache`);
         else
             loggerController.warn(`[${context}] delete don't refreshed cache`);
-        loggerController.debug(`FBCache response: ${resp}`);
+        loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
         next(error);

--- a/src/services/users/users.controller.js
+++ b/src/services/users/users.controller.js
@@ -1,5 +1,5 @@
 import { loggerController } from "../logger/logger.controller";
-import { FBCache, service } from "fbcache";
+import { FBCache } from "fbcache";
 const util = require('util')
 
 const controller = {};
@@ -9,8 +9,9 @@ const context = "Users Controller"
 controller.getAll = async (req, res, next) => {
     loggerController.debug(`[${context}] getAll`);
     loggerController.debug(`route especified: users`);
+    let fbc = new FBCache();
     try {
-        const resp = await FBCache.get(service.FIRESTORE, "users");
+        const resp = await fbc.firestore().collection("users").get();
         if(resp.cache)
             loggerController.info(`[${context}] get users from cache`);
         else
@@ -25,11 +26,12 @@ controller.getAll = async (req, res, next) => {
 controller.insert = async (req, res, next) => {
     const info = req.body;
     let resp = null;
+    let fbc = new FBCache();
     loggerController.debug(`[${context}] insert`);
     loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
     loggerController.debug(`route especified: users`);
     try {
-        resp = await FBCache.insert(service.FIRESTORE, "users", info);
+        resp = await fbc.firestore().collection("users").add(info);
         if(resp.updateCache)
             loggerController.info(`[${context}] insert refreshed cache`);
         else
@@ -45,12 +47,13 @@ controller.insertWithID = async (req, res, next) => {
     const info = req.body;
     const id = req.params.id;
     let resp = null;
+    let fbc = new FBCache();
     loggerController.debug(`[${context}] insertWithID`);
     loggerController.debug(`param 'id' recibed: ${id}`);
     loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
     loggerController.debug(`route especified: users`);
     try {
-        resp = await FBCache.insert(service.FIRESTORE, "users", info, id);
+        resp = await fbc.firestore().collection("users").doc(id).set(info);
         if(resp.updateCache)
             loggerController.info(`[${context}] insert refreshed cache`);
         else
@@ -66,12 +69,13 @@ controller.update = async (req, res, next) => {
     const info = req.body;
     const id = req.params.id;
     let resp = null;
+    let fbc = new FBCache();
     loggerController.debug(`[${context}] update`);
     loggerController.debug(`param 'id' recibed: ${id}`);
     loggerController.debug(`body recibed: ${util.inspect(info, {showHidden: false, depth: null})}`);
     loggerController.debug(`route especified: users`);
     try {
-        resp = await FBCache.update(service.FIRESTORE, "users", info, id);
+        resp = await fbc.firestore().collection("users").doc(id).update(info);
         if(resp.updateCache)
             loggerController.info(`[${context}] update refreshed cache`);
         else
@@ -86,11 +90,12 @@ controller.update = async (req, res, next) => {
 controller.delete = async (req, res, next) => {
     const id = req.params.id;
     let resp = null;
+    let fbc = new FBCache();
     loggerController.debug(`[${context}] delete`);
     loggerController.debug(`param 'id' recibed: ${id}`);
     loggerController.debug(`route especified: users`);
     try {
-        resp = await FBCache.delete(service.FIRESTORE, "users", id);
+        resp = await fbc.firestore().collection("users").doc(id).delete();
         if(resp.updateCache)
             loggerController.info(`[${context}] delete refreshed cache`);
         else

--- a/src/services/users/users.controller.js
+++ b/src/services/users/users.controller.js
@@ -1,4 +1,4 @@
-import { logger } from "../../utils/logger";
+import { loggerController } from "../logger/logger.controller";
 import { FBCache, service } from "fbcache";
 
 const controller = {};
@@ -6,13 +6,14 @@ const controller = {};
 const context = "Users Controller"
 
 controller.getAll = async (req, res, next) => {
-    logger.info(`[${context}] getAll`);
+    loggerController.debug(`[${context}] getAll`);
+    loggerController.debug(`route especified: users`);
     try {
         const resp = await FBCache.get(service.FIRESTORE, "users");
         if(resp.cache)
-            logger.info(`[${context}] getAll users from cache`);
+            loggerController.info(`[${context}] get users from cache`);
         else
-            logger.warn(`[${context}] getAll users from Firestore`);
+            loggerController.warn(`[${context}] get users from Firestore`);
         res.json(resp);
     } catch (error) {
         next(error);
@@ -22,16 +23,77 @@ controller.getAll = async (req, res, next) => {
 controller.insert = async (req, res, next) => {
     const info = req.body;
     let resp = null;
-    logger.info(`[${context}] insert`);
+    loggerController.debug(`[${context}] insert`);
+    loggerController.debug(`body recibed: ${info}`);
+    loggerController.debug(`route especified: users`);
     try {
-        if(info.data)
-            resp = await FBCache.insert(service.FIRESTORE, "users", info.data, info.id);
-        else
-            resp = await FBCache.insert(service.FIRESTORE, "users", info.data);
+        resp = await FBCache.insert(service.FIRESTORE, "users", info);
         if(resp.updateCache)
-            logger.info(`[${context}] insert update cache`);
+            loggerController.info(`[${context}] insert refreshed cache`);
         else
-            logger.warn(`[${context}] insert don't update cache`);
+            loggerController.warn(`[${context}] insert don't refreshed cache`);
+        loggerController.debug(`FBCache response: ${resp}`);
+        res.json(resp);
+    } catch (error) {
+        next(error);
+    }
+}
+
+controller.insertWithID = async (req, res, next) => {
+    const info = req.body;
+    const id = req.params.id;
+    let resp = null;
+    loggerController.debug(`[${context}] insertWithID`);
+    loggerController.debug(`param 'id' recibed: ${id}`);
+    loggerController.debug(`body recibed: ${info}`);
+    loggerController.debug(`route especified: users`);
+    try {
+        resp = await FBCache.insert(service.FIRESTORE, "users", info, id);
+        if(resp.updateCache)
+            loggerController.info(`[${context}] insert refreshed cache`);
+        else
+            loggerController.warn(`[${context}] insert don't refreshed cache`);
+        loggerController.debug(`FBCache response: ${resp}`);
+        res.json(resp);
+    } catch (error) {
+        next(error);
+    }
+}
+
+controller.update = async (req, res, next) => {
+    const info = req.body;
+    const id = req.params.id;
+    let resp = null;
+    loggerController.debug(`[${context}] update`);
+    loggerController.debug(`param 'id' recibed: ${id}`);
+    loggerController.debug(`body recibed: ${info}`);
+    loggerController.debug(`route especified: users`);
+    try {
+        resp = await FBCache.update(service.FIRESTORE, "users", info, id);
+        if(resp.updateCache)
+            loggerController.info(`[${context}] update refreshed cache`);
+        else
+            loggerController.warn(`[${context}] update don't refreshed cache`);
+        loggerController.debug(`FBCache response: ${resp}`);
+        res.json(resp);
+    } catch (error) {
+        next(error);
+    }
+}
+
+controller.delete = async (req, res, next) => {
+    const id = req.params.id;
+    let resp = null;
+    loggerController.debug(`[${context}] delete`);
+    loggerController.debug(`param 'id' recibed: ${id}`);
+    loggerController.debug(`route especified: persons`);
+    try {
+        resp = await FBCache.delete(service.FIRESTORE, "users", id);
+        if(resp.updateCache)
+            loggerController.info(`[${context}] delete refreshed cache`);
+        else
+            loggerController.warn(`[${context}] delete don't refreshed cache`);
+        loggerController.debug(`FBCache response: ${resp}`);
         res.json(resp);
     } catch (error) {
         next(error);

--- a/src/services/users/users.routes.js
+++ b/src/services/users/users.routes.js
@@ -4,5 +4,8 @@ const router = Router();
 
 router.get('/', usersController.getAll);
 router.post('/', usersController.insert);
+router.post('/:id', usersController.insertWithID);
+router.put('/:id', usersController.update);
+router.delete('/:id', usersController.delete)
 
 export const usersRouter = router;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,11 +1,12 @@
 import { createLogger, format, transports } from 'winston';
+import { loggerController } from "../services/logger/logger.controller";
 
 export const logger = createLogger({
     format: format.combine(
         format.simple(),
-        format.timestamp(),
-        format.colorize({ all: true }),
-        format.printf(info => `[${info.timestamp}] - ${info.level} - ${info.message}`)
+        /*format.timestamp(),
+        format.colorize({ all: true }),*/
+        format.printf(info => `${info.level.toUpperCase()} - ${info.message}`)
     ),
     transports: [
         new transports.Console({
@@ -16,6 +17,6 @@ export const logger = createLogger({
 
 logger.stream = {
     write: function(message, encoding){
-        logger.info(message.slice(0, -1));
+        loggerController.info(message.slice(0, -1));
     },
 };


### PR DESCRIPTION
- Se aplicó la recomendación dada la semana pasada sobre la implementación de las rutas que usaban el método _insert_ de FBCache
- Se agregaron rutas para usar los métodos de actualización y eliminación de FBCache
- Se agregó el loggerController para controlar los logs que se quiera que el servidor muestre
- Se habilitó el despliegue automático para cada actualización que reciba la rama "master"
- Se implementó la nueva firma de FBCache

## Como Probar

Antes de todo, es de suma importancia que se tenga a la mano un cliente HTTP como Postman, ya que gran parte de las rutas que se probaran se llaman con los métodos POST, PUT y DELETE. También es recomendable tener la consola de logs de Heroku abierta para ver los logs que se muestran por consola y asegurarse de que todo está en orden

Para asegurar que el servidor esta desplegado, introduzca en su navegador la siguiente dirección: https://fbcacheserver.herokuapp.com/

Le debería aparecer esto en el navegador:
![image](https://user-images.githubusercontent.com/63127022/94305452-3080ee80-ff3f-11ea-8206-6ed6922756b1.png)

Las rutas que se van a probar son las siguientes:
- Obtener todos los registros de una ruta en Real Time Database: GET https://fbcacheserver.herokuapp.com/api/persons

- Insertar un child en una ruta en Real Time Database dejando que Real Time asigne el ID: POST https://fbcacheserver.herokuapp.com/api/persons
Para probar esta ruta, deberá definir un body de formato JSON que contendrá lo que quiera insertar de la siguiente forma:
![image](https://user-images.githubusercontent.com/63127022/94306204-8609cb00-ff40-11ea-9ae5-d3aa4232b62b.png)

Consideraciones: Los atributos del JSON del objeto son referenciales, puede poner cualquier atributo que quiera en el JSON

- Insertar un child en una ruta en Real Time Database indicando el ID con el que se quiere guardar: POST https://fbcacheserver.herokuapp.com/api/persons/:id
Para probar esta ruta se realiza lo mismo que para la anterior, solo que Real Time Database asignará como ID lo que se indique en la ruta en el parámetro id
Advertencia: Al usar este método, si se usa un ID que ya este asignado en la ruta de la inserción, toda la información será cambiada por lo que se envíe en el body

- Actualizar un child en una ruta en Real Time Database dejando que Real Time asigne el ID: PUT https://fbcacheserver.herokuapp.com/api/persons/:id
Esta ruta se prueba igual que la ruta de insertar con id, con la única diferencia que la información que se pase se va agregar a lo que estaba previamente en el child indicado, para entender esto voy a dejar un pequeño ejemplo:

Se tiene un child con ID qwerty, y este tiene la siguiente información:
```
{
     name: "Nombre",
     lastname: "Apellido"
}
```

Si se llama a la ruta de insertar con ID qwerty, y se le pasa un JSON de la siguiente forma:
```
{
     username: "Usuario"
}
```
Ahora cuando veamos lo que contiene el child qwerty en Real Time veremos que solo está el username.

Ahora, si se llamará con la de actualizar y un objeto de la siguiente forma:
```
{
     username: "Usuario",
     name: "Nombre modificado"
}
```

El registro en Real Time Database quedaría de la siguiente forma:
```
{
     name: "Nombre modificado",
     lastname: "Apellido",
     username: "Usuario"
}
```

- Eliminar un child de una ruta de Real Time Database: DELETE https://fbcacheserver.herokuapp.com/api/persons/:id
Para probar esta ruta, únicamente deberá pasar un el ID del child que quiera eliminar por parámetro

Las rutas hacía Firestore tienen un comportamiento similar al descrito para las rutas de Real Time Database, así que esta explicación también sirve para sus homónimas hacía una colección de Firestore
- Obtener todos los registros de Firestore: GET https://fbcacheserver.herokuapp.com/api/users
- Insertar un documento en una colección dejando que Firestore asigne el ID: POST https://fbcacheserver.herokuapp.com/api/users
- Insertar un documento en una colección en Firestore indicando el ID con el que se quiere guardar: POST https://fbcacheserver.herokuapp.com/api/users/:id
- Actualizar un documento en una colección en Firestore dejando que Firestore asigne el ID: PUT https://fbcacheserver.herokuapp.com/api/users/:id
- Eliminar un documento de una colección de Firestore: DELETE https://fbcacheserver.herokuapp.com/api/users/:id

Por último, cuando se apruebe este PR, se ejecutará un despliegue automatico desde la rama master, esto es importante, ya que, el archivo fbcache.config.json en la rama dev actualmente posee un nuevo atributo, el atributo _logs_ que es para utilidad del servidor unicamente, con este atributo se determina cuales logs se mostrarán y cuales no, y si no se indica en el fbcache.config.json o se le pone un valor que no sea el esperado por el servidor, este entrerá por defecto en modo de logs de info. Paso a describir los modos que se pueden asignar desde este atributo:
- debug: Muestra logs de debug, información, warning y error
- info: Muestra logs de información, warning y error unicamente
- error: Muestra logs de warning y error unicamente
El archivo que se encuentra en dev al momento de realizar este PR tiene el valor del atributo _logs_ en debug, y como el archivo de configuración que esta en master (y que lee el servidor en el despliegue por el link a GitHub pages) no tiene ese atributo, el despliegue actualmente estará en modo info, así que debería verse la diferencia cuando se ejecute el despliegue automatico