### PR TITLE
Mejoras post-reunión de pruebas

### DIFF
--- a/docs/config/fbcache.config.json
+++ b/docs/config/fbcache.config.json
@@ -11,7 +11,7 @@
         {
             "name": "persons",
             "period": "20 s",
-            "start": "2020-10-06 04:30:30 am",
+            "start": "2020-10-08 02:00:30 am",
             "read_only": false
         }
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1442,9 +1442,9 @@
       }
     },
     "@google-cloud/common": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.4.0.tgz",
-      "integrity": "sha512-bVMQlK4aZEeopo2oJwDUJiBhPVjRRQHfFCCv9JowmKS3L//PBHNDJzC/LxJixGZEU3fh3YXkUwm67JZ5TBCCNQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.4.1.tgz",
+      "integrity": "sha512-e5z0CwsM0RXky+PnyPtQ3QK46ksqm+kE7kX8pm8X+ddBwZJipHchKeazMM5fLlGCS+AALalzXb+uYmH72TRnpQ==",
       "optional": true,
       "requires": {
         "@google-cloud/projectify": "^2.0.0",
@@ -1453,7 +1453,7 @@
         "duplexify": "^4.1.1",
         "ent": "^2.2.0",
         "extend": "^3.0.2",
-        "google-auth-library": "^6.0.0",
+        "google-auth-library": "^6.1.1",
         "retry-request": "^4.1.1",
         "teeny-request": "^7.0.0"
       }
@@ -2953,8 +2953,8 @@
       }
     },
     "fbcache": {
-      "version": "git+https://github.com/synergyvision/fbcache.git#140720e2a14d21ab472d81ac8c755976a16e4936",
-      "from": "git+https://github.com/synergyvision/fbcache.git#dev",
+      "version": "git+https://github.com/synergyvision/fbcache.git#a8064ec4821b1f0ac243a877ab05e37be770ade1",
+      "from": "git+https://github.com/synergyvision/fbcache.git#master",
       "requires": {
         "firebase-admin": "9.1.1",
         "moment": "2.27.0",
@@ -3217,9 +3217,9 @@
       "dev": true
     },
     "google-auth-library": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.0.tgz",
-      "integrity": "sha512-GbalszIADE1YPWhUyfFMrkLhFHnlAgoRcqGVW+MsLDPsuaOB5MRPk7NNafPDv9SherNE4EKzcYuxMJjaxzXMOw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.1.tgz",
+      "integrity": "sha512-0WfExOx3FrLYnY88RICQxvpaNzdwjz44OsHqHkIoAJfjY6Jck6CZRl1ASWadk+wbJ0LhkQ8rNY4zZebKml4Ghg==",
       "optional": true,
       "requires": {
         "arrify": "^2.0.0",
@@ -3228,7 +3228,7 @@
         "fast-text-encoding": "^1.0.0",
         "gaxios": "^3.0.0",
         "gcp-metadata": "^4.1.0",
-        "gtoken": "^5.0.0",
+        "gtoken": "^5.0.4",
         "jws": "^4.0.0",
         "lru-cache": "^6.0.0"
       }
@@ -3293,13 +3293,13 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "gtoken": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.3.tgz",
-      "integrity": "sha512-Nyd1wZCMRc2dj/mAD0LlfQLcAO06uKdpKJXvK85SGrF5+5+Bpfil9u/2aw35ltvEHjvl0h5FMKN5knEU+9JrOg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.4.tgz",
+      "integrity": "sha512-U9wnSp4GZ7ov6zRdPuRHG4TuqEWqRRgT1gfXGNArhzBUn9byrPeH8uTmBWU/ZiWJJvTEmkjhDIC3mqHWdVi3xQ==",
       "optional": true,
       "requires": {
         "gaxios": "^3.0.0",
-        "google-p12-pem": "^3.0.0",
+        "google-p12-pem": "^3.0.3",
         "jws": "^4.0.0",
         "mime": "^2.2.0"
       },
@@ -5567,9 +5567,9 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz",
+      "integrity": "sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw=="
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fbcache-servidor",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Test server for the FBCache library",
   "main": "dist/index.js",
   "directories": {
@@ -36,7 +36,7 @@
     "axios": "^0.20.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "fbcache": "git+https://github.com/synergyvision/fbcache.git#dev",
+    "fbcache": "git+https://github.com/synergyvision/fbcache.git#master",
     "morgan": "^1.10.0",
     "winston": "^3.3.3"
   },

--- a/src/app/server.js
+++ b/src/app/server.js
@@ -66,5 +66,3 @@ app.use(function(err, req, res, next) {
     loggerController.error(err.message);
     res.status(500).send({ error: "SERVER_ERROR", message: err.message });
 });
-
-process.on('unhandledRejection', (reason, p) => {});

--- a/src/app/server.js
+++ b/src/app/server.js
@@ -56,6 +56,10 @@ app.get('/', (req, res) => {
     res.json("FBCache Server is running")
 });
 app.use('/api', apiRouter);
+app.get('*', (req, res) => {
+    loggerController.warn("Invalid route")
+    res.status(404).send({ error: "NOT_FOUND", message: "Invalid route" })
+})
 
 // ERROR HANDLER
 app.use(function(err, req, res, next) {

--- a/src/services/persons/persons.controller.js
+++ b/src/services/persons/persons.controller.js
@@ -11,7 +11,7 @@ controller.getAll = async (req, res, next) => {
     const id = req.query.id;
     if(id)
         route = route + "/" + id;
-    loggerController.debug(`[${context}] getAll`);
+    loggerController.debug(`[${context}] get`);
     loggerController.debug(`route especified: ${route}`);
     let fbc = new FBCache();
     try {

--- a/src/services/persons/persons.controller.js
+++ b/src/services/persons/persons.controller.js
@@ -7,15 +7,19 @@ const controller = {};
 const context = "Persons Controller"
 
 controller.getAll = async (req, res, next) => {
+    let route = "persons";
+    const id = req.query.id;
+    if(id)
+        route = route + "/" + id;
     loggerController.debug(`[${context}] getAll`);
-    loggerController.debug(`route especified: persons`);
+    loggerController.debug(`route especified: ${route}`);
     let fbc = new FBCache();
     try {
-        const resp = await fbc.database().ref("persons").once();
+        const resp = await fbc.database().ref(route).once();
         if(resp.cache)
-            loggerController.info(`[${context}] get persons from cache`);
+            loggerController.info(`[${context}] get ${route} from cache`);
         else
-            loggerController.warn(`[${context}] get persons from Real Time Database`);
+            loggerController.warn(`[${context}] get ${route} from Real Time Database`);
         loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
@@ -33,9 +37,9 @@ controller.insert = async (req, res, next) => {
     try {
         resp = await fbc.database().ref().child("persons").push(info);
         if(resp.updateCache)
-            loggerController.info(`[${context}] insert refreshed cache`);
+            loggerController.info(`[${context}] insert refresh cache`);
         else
-            loggerController.warn(`[${context}] insert don't refreshed cache`);
+            loggerController.warn(`[${context}] insert don't refresh cache`);
         loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
@@ -55,9 +59,9 @@ controller.insertWithID = async (req, res, next) => {
     try {
         resp = await fbc.database().ref("persons").child(id).set(info);
         if(resp.updateCache)
-            loggerController.info(`[${context}] insert refreshed cache`);
+            loggerController.info(`[${context}] insert refresh cache`);
         else
-            loggerController.warn(`[${context}] insert don't refreshed cache`);
+            loggerController.warn(`[${context}] insert don't refresh cache`);
         loggerController.debug(`FBCache response: ${util.inspect(info, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
@@ -77,9 +81,9 @@ controller.update = async (req, res, next) => {
     try {
         resp = await fbc.database().ref("persons").child(id).update(info);
         if(resp.updateCache)
-            loggerController.info(`[${context}] update refreshed cache`);
+            loggerController.info(`[${context}] update refresh cache`);
         else
-            loggerController.warn(`[${context}] update don't refreshed cache`);
+            loggerController.warn(`[${context}] update don't refresh cache`);
         loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
@@ -97,9 +101,9 @@ controller.delete = async (req, res, next) => {
     try {
         resp = await fbc.database().ref("persons").child(id).remove();
         if(resp.updateCache)
-            loggerController.info(`[${context}] delete refreshed cache`);
+            loggerController.info(`[${context}] delete refresh cache`);
         else
-            loggerController.warn(`[${context}] delete don't refreshed cache`);
+            loggerController.warn(`[${context}] delete don't refresh cache`);
         loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {

--- a/src/services/persons/persons.controller.js
+++ b/src/services/persons/persons.controller.js
@@ -8,7 +8,7 @@ const context = "Persons Controller"
 
 controller.getAll = async (req, res, next) => {
     let route = "persons";
-    const id = req.query.id;
+    const id = req.params.id;
     if(id)
         route = route + "/" + id;
     loggerController.debug(`[${context}] get`);

--- a/src/services/persons/persons.routes.js
+++ b/src/services/persons/persons.routes.js
@@ -3,6 +3,7 @@ import { personsController } from "./persons.controller";
 const router = Router();
 
 router.get('/', personsController.getAll)
+router.get('/:id(*)', personsController.getAll)
 router.post('/', personsController.insert)
 router.post('/:id', personsController.insertWithID)
 router.put('/:id', personsController.update)

--- a/src/services/users/users.controller.js
+++ b/src/services/users/users.controller.js
@@ -8,7 +8,7 @@ const context = "Users Controller"
 
 controller.getAll = async (req, res, next) => {
     let route = "users";
-    const id = req.query.id;
+    const id = req.params.id;
     if(id)
         route = route + "/" + id;
     loggerController.debug(`[${context}] get`);

--- a/src/services/users/users.controller.js
+++ b/src/services/users/users.controller.js
@@ -7,15 +7,19 @@ const controller = {};
 const context = "Users Controller"
 
 controller.getAll = async (req, res, next) => {
+    let route = "users";
+    const id = req.query.id;
+    if(id)
+        route = route + "/" + id;
     loggerController.debug(`[${context}] getAll`);
-    loggerController.debug(`route especified: users`);
+    loggerController.debug(`route especified: ${route}`);
     let fbc = new FBCache();
     try {
-        const resp = await fbc.firestore().collection("users").get();
+        const resp = await fbc.firestore().collection(route).get();
         if(resp.cache)
-            loggerController.info(`[${context}] get users from cache`);
+            loggerController.info(`[${context}] get ${route} from cache`);
         else
-            loggerController.warn(`[${context}] get users from Firestore`);
+            loggerController.warn(`[${context}] get ${route} from Firestore`);
         loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
@@ -33,9 +37,9 @@ controller.insert = async (req, res, next) => {
     try {
         resp = await fbc.firestore().collection("users").add(info);
         if(resp.updateCache)
-            loggerController.info(`[${context}] insert refreshed cache`);
+            loggerController.info(`[${context}] insert refresh cache`);
         else
-            loggerController.warn(`[${context}] insert don't refreshed cache`);
+            loggerController.warn(`[${context}] insert don't refresh cache`);
         loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
@@ -55,9 +59,9 @@ controller.insertWithID = async (req, res, next) => {
     try {
         resp = await fbc.firestore().collection("users").doc(id).set(info);
         if(resp.updateCache)
-            loggerController.info(`[${context}] insert refreshed cache`);
+            loggerController.info(`[${context}] insert refresh cache`);
         else
-            loggerController.warn(`[${context}] insert don't refreshed cache`);
+            loggerController.warn(`[${context}] insert don't refresh cache`);
         loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
@@ -77,9 +81,9 @@ controller.update = async (req, res, next) => {
     try {
         resp = await fbc.firestore().collection("users").doc(id).update(info);
         if(resp.updateCache)
-            loggerController.info(`[${context}] update refreshed cache`);
+            loggerController.info(`[${context}] update refresh cache`);
         else
-            loggerController.warn(`[${context}] update don't refreshed cache`);
+            loggerController.warn(`[${context}] update don't refresh cache`);
         loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {
@@ -97,9 +101,9 @@ controller.delete = async (req, res, next) => {
     try {
         resp = await fbc.firestore().collection("users").doc(id).delete();
         if(resp.updateCache)
-            loggerController.info(`[${context}] delete refreshed cache`);
+            loggerController.info(`[${context}] delete refresh cache`);
         else
-            loggerController.warn(`[${context}] delete don't refreshed cache`);
+            loggerController.warn(`[${context}] delete don't refresh cache`);
         loggerController.debug(`FBCache response: ${util.inspect(resp, {showHidden: false, depth: null})}`);
         res.json(resp);
     } catch (error) {

--- a/src/services/users/users.controller.js
+++ b/src/services/users/users.controller.js
@@ -11,7 +11,7 @@ controller.getAll = async (req, res, next) => {
     const id = req.query.id;
     if(id)
         route = route + "/" + id;
-    loggerController.debug(`[${context}] getAll`);
+    loggerController.debug(`[${context}] get`);
     loggerController.debug(`route especified: ${route}`);
     let fbc = new FBCache();
     try {

--- a/src/services/users/users.routes.js
+++ b/src/services/users/users.routes.js
@@ -3,6 +3,7 @@ import { usersController } from "./users.controller";
 const router = Router();
 
 router.get('/', usersController.getAll);
+router.get('/:id(*)', usersController.getAll);
 router.post('/', usersController.insert);
 router.post('/:id', usersController.insertWithID);
 router.put('/:id', usersController.update);


### PR DESCRIPTION
- Implementa respuesta para rutas que generen un error 404
- Arregla algunos logs
- Implementa las mejoras al método get
- Ahora fbcache en el package.json referencia a master y no a dev

## ¿Como probar?

**NOTA**: Primero, asegurese de que el PR de mejoras de la librería FBCache ya se encuentre aceptado
- Para usar el método para consultar a un child o documento en especifico de la ruta especificada, haga lo siguiente:

1. Escriba en su cliente HTTP el URL https://fbcacheserver.herokuapp.com/api/persons (esto para Real Time Database) o https://fbcacheserver.herokuapp.com/api/users (esto para Firestore)

2. Luego, vaya a la sección de "Params" y declare un parámetro llamado id y asígnele el id en especifico que quiera consultar:
![image](https://user-images.githubusercontent.com/63127022/95299757-34b8e000-084c-11eb-838f-2e2b7e9156b0.png)

3. Luego de haber realizado esto, asegúrese de que esta llamando al URL con el método GET y realice la petición HTTP, le debería dar un resultado como este donde _info_ tiene la información exacta que usted solicitó:
![image](https://user-images.githubusercontent.com/63127022/95300068-a8f38380-084c-11eb-9164-722c13b76594.png)

4. En caso que quiera un atributo en especifico de dicho resultado, puede poner el id de la siguiente forma:
![image](https://user-images.githubusercontent.com/63127022/95300327-012a8580-084d-11eb-9f35-eb6569053ecd.png)

Y le traerá exactamente la información de ese atributo
![image](https://user-images.githubusercontent.com/63127022/95300401-18697300-084d-11eb-9ec4-24aaf41e695d.png)

### Actualización
Ya no es necesario declarar un parametro, con poner el id en la ruta es suficiente
